### PR TITLE
Version 4.5.1

### DIFF
--- a/core/abre_functions.php
+++ b/core/abre_functions.php
@@ -687,6 +687,48 @@
 		return $valuereturn;
 	}
 
+	function getUpdateRequiredDbValue(){
+		include "abre_dbconnect.php";
+		$sql2 = "SELECT `update_required` FROM settings LIMIT 1";
+		$result2 = $db->query($sql2);
+		if($result2){
+			$row = $result2->fetch_assoc();
+			if($row["update_required"] == 0){
+				return false;
+			}else{
+				return true;
+			}
+		}else{
+			$sql = "ALTER TABLE `settings` ADD `update_required` int(11) NOT NULL DEFAULT '1';";
+			$db->multi_query($sql);
+			return true;
+		}
+	}
+
+	function isAppInstalled($appName){
+		include "abre_dbconnect.php";
+		$sql = "SELECT COUNT(*) FROM apps_abre WHERE app='$appName' AND installed = 1";
+		$query = $db->query($sql);
+		$result = $query->fetch_assoc();
+		$count = $result["COUNT(*)"];
+		if($count == 1){
+			return true;
+		}
+		return false;
+	}
+
+	function isAppActive($appName){
+		include "abre_dbconnect.php";
+		$sql = "SELECT COUNT(*) FROM apps_abre WHERE app='$appName' AND active = 1";
+		$query = $db->query($sql);
+		$result = $query->fetch_assoc();
+		$count = $result["COUNT(*)"];
+		if($count == 1){
+			return true;
+		}
+		return false;
+	}
+
 	function linkify($value, $protocols = array('http', 'mail'), array $attributes = array()){
 		// Link attributes
 		$attr = '';

--- a/core/abre_functions.php
+++ b/core/abre_functions.php
@@ -729,6 +729,27 @@
 		return false;
 	}
 
+	function activateApp($appName){
+		include "abre_dbconnect.php";
+		$active = 1;
+		$installed = 0;
+
+		$stmt = $db->stmt_init();
+		$insertSql = "INSERT INTO apps_abre (app, active, installed) VALUES (?, ?, ?)";
+		$stmt->prepare($insertSql);
+
+		$sql = "SELECT COUNT(*) FROM apps_abre WHERE app = '$appName'";
+		$query = $db->query($sql);
+		$result = $query->fetch_assoc();
+		$count = $result["COUNT(*)"];
+		if($count == 0){
+			$stmt->bind_param("sii", $appName, $active, $installed);
+			$stmt->execute();
+		}
+		$stmt->close();
+		$db->close();
+	}
+
 	function linkify($value, $protocols = array('http', 'mail'), array $attributes = array()){
 		// Link attributes
 		$attr = '';

--- a/core/abre_installer_process.php
+++ b/core/abre_installer_process.php
@@ -111,7 +111,7 @@
 	    }
 
 			//Create required database tables
-		$sql = "CREATE TABLE `users` (`id` int(11) NOT NULL,`email` text NOT NULL,`superadmin` int(11) NOT NULL DEFAULT '0',`refresh_token` text NOT NULL,`cookie_token` text NOT NULL, `auth_service` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=latin1;";
+		$sql = "CREATE TABLE `users` (`id` int(11) NOT NULL,`email` text NOT NULL,`superadmin` int(11) NOT NULL DEFAULT '0',`admin` int(11) NOT NULL DEFAULT '0',`refresh_token` text NOT NULL,`cookie_token` text NOT NULL, `auth_service` text NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=latin1;";
 		$sql .= "ALTER TABLE `users` ADD PRIMARY KEY (`id`);";
 		$sql .= "ALTER TABLE `users` MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;";
 

--- a/core/abre_version.php
+++ b/core/abre_version.php
@@ -16,6 +16,6 @@
 	* version 3 along with this program.  If not, see https://www.gnu.org/licenses/agpl-3.0.en.html.
 	*/
 
-	$abre_version = '4.5.0';
+	$abre_version = '4.5.1';
 
 ?>

--- a/modules/Abre-Assessments/config.php
+++ b/modules/Abre-Assessments/config.php
@@ -29,7 +29,7 @@
 	$pagetitle="Assessments";
 	$description="Create & deliver standards-aligned assessments";
 	$version="1.4.8";
-	$repo="abreio/Abre-Assessments";
+	$repo= NULL;
 	$pageicon="assessment";
 	$pagepath="assessments";
 	require_once('permissions.php');

--- a/modules/Abre-Assessments/config.php
+++ b/modules/Abre-Assessments/config.php
@@ -19,19 +19,20 @@
 	//Required configuration files
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
-	$pageview=1;
-	$drawerhidden=1;
-	$pageorder=4;
-	$pagetitle="Assessments";
-	$description="Create & deliver standards-aligned assessments";
-	$version="1.4.8";
-	$repo= NULL;
-	$pageicon="assessment";
-	$pagepath="assessments";
+	$pageview = 1;
+	$drawerhidden = 1;
+	$pageorder = 4;
+	$pagetitle = "Assessments";
+	$description = "Create & deliver standards-aligned assessments";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "assessment";
+	$pagepath = "assessments";
 	require_once('permissions.php');
 
 	echo "<link rel='stylesheet' type='text/css' href='/modules/".basename(__DIR__)."/css/style_0.0.2.css'>";

--- a/modules/Abre-Assessments/installer.php
+++ b/modules/Abre-Assessments/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Assessments/setup.txt"))
+	if(superadmin() && !isAppInstalled("Abre-Assessments"))
 	{
 
 		//Check for assessments_settings table
@@ -500,11 +500,11 @@
 		}
 		$db->close();
 
-
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Assessments/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Assessments'";
+		$db->multi_query($sql);
+		$db->close();
 
 	}
 

--- a/modules/Abre-Books/config.php
+++ b/modules/Abre-Books/config.php
@@ -30,7 +30,7 @@
 	$pagetitle="Books";
 	$description="An ePub reader for digital books.";
 	$version="2.2.2";
-	$repo="abreio/Abre-Books";
+	$repo=NULL;
 	$pageicon="local_library";
 	$pagepath="books";
 

--- a/modules/Abre-Books/config.php
+++ b/modules/Abre-Books/config.php
@@ -20,19 +20,20 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
-	$pageview=1;
-	$drawerhidden=0;
-	$pageorder=2;
-	$pagetitle="Books";
-	$description="An ePub reader for digital books.";
-	$version="2.2.2";
-	$repo=NULL;
-	$pageicon="local_library";
-	$pagepath="books";
+	$pageview = 1;
+	$drawerhidden = 0;
+	$pageorder = 2;
+	$pagetitle = "Books";
+	$description = "An ePub reader for digital books.";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "local_library";
+	$pagepath = "books";
 
 	require_once('permissions.php');
 

--- a/modules/Abre-Books/installer.php
+++ b/modules/Abre-Books/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Books/setup.txt"))
+	if(superadmin() && !isAppInstalled("Abre-Books"))
 	{
 
 		//Create Books folder if one does not exist
@@ -171,10 +171,11 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Books/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Books'";
+		$db->multi_query($sql);
+		$db->close();
 
 	}
 

--- a/modules/Abre-Conduct/closed_display.php
+++ b/modules/Abre-Conduct/closed_display.php
@@ -238,7 +238,7 @@
 			var Reload = $(this).data('reload');
 			$("#Incident_Reload").val(Reload);
 			var StudentName = $(this).data('studentname');
-			<?php if(file_exists("$portal_path_root/modules/Abre-Students/setup.txt")){ ?>
+			<?php if(isAppActive("Abre-Students")){ ?>
 								$("#conducttitle").html(StudentName+' <a class="modal-studentlook" data-studentid="'+Student_ID+'" href="#studentlook" style="color:#fff;"><i class="material-icons">remove_red_eye</i></a>');
 			<?php }else{ ?>
 								$("#conducttitle").html(StudentName);

--- a/modules/Abre-Conduct/config.php
+++ b/modules/Abre-Conduct/config.php
@@ -19,20 +19,21 @@
 	//Required configuration files
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
 	echo "<link rel='stylesheet' type='text/css' href='/modules/Abre-Conduct/style/style.0.0.8.css'>";
 
-	$pageview=1;
-	$drawerhidden=1;
-	$pageorder=4;
-	$pagetitle="Conduct";
-	$description="Record, store, & track student behavior.";
-	$version="0.5.8";
-	$repo=NULL;
-	$pageicon="gavel";
-	$pagepath="conduct/discipline/open";
+	$pageview = 1;
+	$drawerhidden = 1;
+	$pageorder = 4;
+	$pagetitle = "Conduct";
+	$description = "Record, store, & track student behavior.";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "gavel";
+	$pagepath = "conduct/discipline/open";
 	require_once('permissions.php');
 ?>

--- a/modules/Abre-Conduct/config.php
+++ b/modules/Abre-Conduct/config.php
@@ -31,7 +31,7 @@
 	$pagetitle="Conduct";
 	$description="Record, store, & track student behavior.";
 	$version="0.5.8";
-	$repo="abreio/Abre-Conduct";
+	$repo=NULL;
 	$pageicon="gavel";
 	$pagepath="conduct/discipline/open";
 	require_once('permissions.php');

--- a/modules/Abre-Conduct/installer.php
+++ b/modules/Abre-Conduct/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Conduct/setup.txt")){
+	if(superadmin() && !isAppInstalled("Abre-Conduct")){
 
 		//Check for conduct_colors table
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -459,9 +459,10 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Conduct/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Conduct'";
+		$db->multi_query($sql);
+		$db->close();
 	}
 ?>

--- a/modules/Abre-Conduct/queue_display.php
+++ b/modules/Abre-Conduct/queue_display.php
@@ -247,7 +247,7 @@
 			var Reload = $(this).data('reload');
 			$("#Incident_Reload").val(Reload);
 			var StudentName = $(this).data('studentname');
-			<?php if(file_exists("$portal_path_root/modules/Abre-Students/setup.txt")){ ?>
+			<?php if(isAppActive("Abre-Students")){ ?>
 								$("#conducttitle").html(StudentName+' <a class="modal-studentlook" data-studentid="'+Student_ID+'" href="#studentlook" style="color:#fff;"><i class="material-icons">remove_red_eye</i></a>');
 			<?php }else{ ?>
 								$("#conducttitle").html(StudentName);

--- a/modules/Abre-Conduct/verification_display.php
+++ b/modules/Abre-Conduct/verification_display.php
@@ -247,7 +247,7 @@
 			var Reload = $(this).data('reload');
 			$("#Incident_Reload").val(Reload);
 			var StudentName = $(this).data('studentname');
-			<?php if(file_exists("$portal_path_root/modules/Abre-Students/setup.txt")){ ?>
+			<?php if(isAppActive("Abre-Students")){ ?>
 								$("#conducttitle").html(StudentName+' <a class="modal-studentlook" data-studentid="'+Student_ID+'" href="#studentlook" style="color:#fff;"><i class="material-icons">remove_red_eye</i></a>');
 			<?php }else{ ?>
 								$("#conducttitle").html(StudentName);

--- a/modules/Abre-Curriculum/config.php
+++ b/modules/Abre-Curriculum/config.php
@@ -28,7 +28,7 @@
 	$pagetitle="Curriculum";
 	$description="A curriculum organizer and lesson planner for teachers.";
 	$version="2.2.4";
-	$repo="abreio/Abre-Curriculum";
+	$repo=NULL;
 	$pageicon="layers";
 	$pagepath="curriculum";
 

--- a/modules/Abre-Curriculum/config.php
+++ b/modules/Abre-Curriculum/config.php
@@ -18,19 +18,20 @@
 
 	//Required configuration files
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
-	$pageview=1;
-	$drawerhidden=0;
-	$pageorder=3;
-	$pagetitle="Curriculum";
-	$description="A curriculum organizer and lesson planner for teachers.";
-	$version="2.2.4";
-	$repo=NULL;
-	$pageicon="layers";
-	$pagepath="curriculum";
+	$pageview = 1;
+	$drawerhidden = 0;
+	$pageorder = 3;
+	$pagetitle = "Curriculum";
+	$description = "A curriculum organizer and lesson planner for teachers.";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "layers";
+	$pagepath = "curriculum";
 
 	require_once('permissions.php');
 

--- a/modules/Abre-Curriculum/installer.php
+++ b/modules/Abre-Curriculum/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Curriculum/setup.txt"))
+	if(superadmin() && !isAppInstalled("Abre-Curriculum"))
 	{
 		//Check for curriculum_course table
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -547,10 +547,11 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Curriculum/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Curriculum'";
+		$db->multi_query($sql);
+		$db->close();
 
 	}
 

--- a/modules/Abre-Forms/config.php
+++ b/modules/Abre-Forms/config.php
@@ -20,20 +20,21 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
 	echo "<link rel='stylesheet' href='/modules/Abre-Forms/css/style_0.0.8.css'>";
 
-	$pageview=1;
-	$pageorder=2;
-	$drawerhidden=0;
-	$pagetitle="Forms";
-	$description="Create forms and collect data from staff, students, and parents.";
-	$version="0.2.3";
-	$repo=NULL;
-	$pageicon="assignment_turned_in";
-	$pagepath="forms";
+	$pageview = 1;
+	$pageorder = 2;
+	$drawerhidden = 0;
+	$pagetitle = "Forms";
+	$description = "Create forms and collect data from staff, students, and parents.";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "assignment_turned_in";
+	$pagepath = "forms";
 
 ?>

--- a/modules/Abre-Forms/config.php
+++ b/modules/Abre-Forms/config.php
@@ -32,7 +32,7 @@
 	$pagetitle="Forms";
 	$description="Create forms and collect data from staff, students, and parents.";
 	$version="0.2.3";
-	$repo="abreio/Abre-Forms";
+	$repo=NULL;
 	$pageicon="assignment_turned_in";
 	$pagepath="forms";
 

--- a/modules/Abre-Forms/installer.php
+++ b/modules/Abre-Forms/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Forms/setup.txt"))
+	if(superadmin() && !isAppInstalled("Abre-Forms"))
 	{
 		//Check for forms table
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -229,10 +229,11 @@
 			}
 		}
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Forms/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Forms'";
+		$db->multi_query($sql);
+		$db->close();
 
 	}
 

--- a/modules/Abre-Forms/view_builder.php
+++ b/modules/Abre-Forms/view_builder.php
@@ -75,7 +75,7 @@
 	else
 	{
 
-		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Edit Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please contact the form owner to request access.</p></div>";
+		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Edit Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please request access from the form owner.</p></div>";
 
 	}
 

--- a/modules/Abre-Forms/view_forms_display.php
+++ b/modules/Abre-Forms/view_forms_display.php
@@ -51,10 +51,10 @@
 
 		if($searchquery == ""){
 			$querycount = "SELECT COUNT(*) FROM forms WHERE Owner = '".$_SESSION['useremail']."'";
-			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE Owner = '".$_SESSION['useremail']."' LIMIT $LowerBound, $PerPage";
+			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE Owner = '".$_SESSION['useremail']."' ORDER BY LastModified DESC LIMIT $LowerBound, $PerPage";
 		}else{
 			$querycount = "SELECT COUNT(*) FROM forms WHERE (LOWER(Name) LIKE '%$searchquery%') AND Owner = '".$_SESSION['useremail']."'";
-			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE (LOWER(Name) LIKE '%$searchquery%') AND Owner = '".$_SESSION['useremail']."' LIMIT $LowerBound, $PerPage";
+			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE (LOWER(Name) LIKE '%$searchquery%') AND Owner = '".$_SESSION['useremail']."' ORDER BY LastModified DESC LIMIT $LowerBound, $PerPage";
 		}
 
 		$result = $db->query($sql);

--- a/modules/Abre-Forms/view_preview.php
+++ b/modules/Abre-Forms/view_preview.php
@@ -133,7 +133,7 @@
 
 	}else{
 
-		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Edit Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please contact the form owner to request access.</p></div>";
+		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Edit Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please request access from the form owner.</p></div>";
 
 	}
 

--- a/modules/Abre-Forms/view_recommended.php
+++ b/modules/Abre-Forms/view_recommended.php
@@ -70,7 +70,7 @@
 				$('.mdl-layout__content').animate({scrollTop:0}, 0);
 				var currentPage = $(this).data('page');
 				var searchQuery = $('#searchquery').val();
-				$.post( "modules/Abre-Forms/view_template_display.php", {page: currentPage, searchquery: searchQuery})
+				$.post( "modules/Abre-Forms/view_recommended_display.php", {page: currentPage, searchquery: searchQuery})
 				.done(function(data){
 					$("#displayforms").html(data);
 					mdlregister();

--- a/modules/Abre-Forms/view_response_summary.php
+++ b/modules/Abre-Forms/view_response_summary.php
@@ -153,7 +153,7 @@
 
 		$resultsSummaryJSON = json_encode($resultsSummaryArray);
 	}else{
-		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Response Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please contact the form owner to request access.</p></div>";
+		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Response Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please request access from the form owner.</p></div>";
 	}
 ?>
 

--- a/modules/Abre-Forms/view_responses.php
+++ b/modules/Abre-Forms/view_responses.php
@@ -62,13 +62,12 @@
 					echo "<div class='widget' style='padding:30px; text-align:center; width:100%;'><p style='font-size: 22px; font-weight:700;'>No Responses Yet</p></div>";
 			echo "</div>";
 		}
-
-
+		
 	}
 	else
 	{
 
-		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Response Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please contact the form owner to request access.</p></div>";
+		echo "<div class='row' style='padding:56px; text-align:center; width:100%;'><span style='font-size: 22px; font-weight:700'>You Do Not Have Response Access</span><br><p style='font-size:16px; margin:20px 0 0 0;'>Please request access from the form owner.</p></div>";
 
 	}
 ?>

--- a/modules/Abre-Forms/view_settings.php
+++ b/modules/Abre-Forms/view_settings.php
@@ -119,7 +119,7 @@
 						echo "<label for='template' style='color:#000;'> Make this form a district template</label>";
 					echo "</div>";
 				echo "</div>";
-				if(file_exists("$portal_path_root/modules/Abre-Plans/setup.txt")){
+				if(isAppActive("Abre-Plans")){
 					echo "<div class='row'>";
 						echo "<div class='col s12'>";
 							echo "<input type='checkbox' class='filled-in' id='plan' name='plan' value='checked' ".getFormsSettingsPlan($id)."/>";

--- a/modules/Abre-Forms/view_shared_forms_display.php
+++ b/modules/Abre-Forms/view_shared_forms_display.php
@@ -51,10 +51,10 @@
 
 		if($searchquery == ""){
 			$querycount = "SELECT COUNT(*) FROM forms WHERE Editors LIKE '%".$_SESSION['useremail']."%' OR ResponseAccess LIKE '%".$_SESSION['useremail']."%'";
-			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE Editors LIKE '%".$_SESSION['useremail']."%' OR ResponseAccess LIKE '%".$_SESSION['useremail']."%' LIMIT $LowerBound, $PerPage";
+			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE Editors LIKE '%".$_SESSION['useremail']."%' OR ResponseAccess LIKE '%".$_SESSION['useremail']."%' ORDER BY LastModified DESC LIMIT $LowerBound, $PerPage";
 		}else{
 			$querycount = "SELECT COUNT(*) FROM forms WHERE (LOWER(Name) LIKE '%$searchquery%') AND (Editors LIKE '%".$_SESSION['useremail']."%' OR ResponseAccess LIKE '%".$_SESSION['useremail']."%')";
-			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE (LOWER(Name) LIKE '%$searchquery%') AND (Editors LIKE '%".$_SESSION['useremail']."%' OR ResponseAccess LIKE '%".$_SESSION['useremail']."%') LIMIT $LowerBound, $PerPage";
+			$sql = "SELECT ID, Name, Owner, LastModified FROM forms WHERE (LOWER(Name) LIKE '%$searchquery%') AND (Editors LIKE '%".$_SESSION['useremail']."%' OR ResponseAccess LIKE '%".$_SESSION['useremail']."%') ORDER BY LastModified DESC LIMIT $LowerBound, $PerPage";
 		}
 
 		$result = $db->query($sql);

--- a/modules/Abre-Guided-Learning/config.php
+++ b/modules/Abre-Guided-Learning/config.php
@@ -20,19 +20,20 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
-	$pageview=1;
-	$drawerhidden=0;
-	$pageorder=10;
-	$pagetitle="Guided Learning";
-	$description="Secure lesson builder for delivering a focused lesson with Guided Learning App or Guided Learning Extension.";
-	$version="1.1.1";
-	$repo=NULL;
-	$pageicon="directions";
-	$pagepath="guide";
+	$pageview = 1;
+	$drawerhidden = 0;
+	$pageorder = 10;
+	$pagetitle = "Guided Learning";
+	$description = "Secure lesson builder for delivering a focused lesson with Guided Learning App or Guided Learning Extension.";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "directions";
+	$pagepath = "guide";
 
 	require_once('permissions.php');
 

--- a/modules/Abre-Guided-Learning/config.php
+++ b/modules/Abre-Guided-Learning/config.php
@@ -30,7 +30,7 @@
 	$pagetitle="Guided Learning";
 	$description="Secure lesson builder for delivering a focused lesson with Guided Learning App or Guided Learning Extension.";
 	$version="1.1.1";
-	$repo="abreio/Abre-Guided-Learning";
+	$repo=NULL;
 	$pageicon="directions";
 	$pagepath="guide";
 

--- a/modules/Abre-Guided-Learning/installer.php
+++ b/modules/Abre-Guided-Learning/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Guided-Learning/setup.txt"))
+	if(superadmin() && !isAppInstalled("Abre-Guided-Learning"))
 	{
 		//Check for guide_boards table
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -158,10 +158,11 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Guided-Learning/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Guided-Learning'";
+		$db->multi_query($sql);
+		$db->close();
 
 	}
 

--- a/modules/Abre-Students/config.php
+++ b/modules/Abre-Students/config.php
@@ -21,19 +21,20 @@
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 	require_once('permissions.php');
+	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	echo "<link rel='stylesheet' href='modules/".basename(__DIR__)."/css/style.1.0.css'>";
 
 	//Check for installation
 	if(admin()){ require('installer.php'); }
 
-	$pageview=1;
-	$pageorder=2;
-	$pagetitle="Students";
-	$description="A student data dashboard for staff and parents.";
-	$version="1.4.9";
-	$repo=NULL;
-	$pageicon="supervisor_account";
+	$pageview = 1;
+	$pageorder = 2;
+	$pagetitle = "Students";
+	$description = "A student data dashboard for staff and parents.";
+	$version = $abre_version;
+	$repo = NULL;
+	$pageicon = "supervisor_account";
 	if($isParent){
 		$pagepath = "mystudents";
 	}else{

--- a/modules/Abre-Students/config.php
+++ b/modules/Abre-Students/config.php
@@ -32,7 +32,7 @@
 	$pagetitle="Students";
 	$description="A student data dashboard for staff and parents.";
 	$version="1.4.9";
-	$repo="abreio/Abre-Students";
+	$repo=NULL;
 	$pageicon="supervisor_account";
 	if($isParent){
 		$pagepath = "mystudents";

--- a/modules/Abre-Students/installer.php
+++ b/modules/Abre-Students/installer.php
@@ -20,8 +20,9 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/Abre-Students/setup.txt"))
+	if(superadmin() && !isAppInstalled("Abre-Students"))
 	{
+
 		//Check for students_groups table
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 		if(!$db->query("SELECT * FROM students_groups LIMIT 1"))
@@ -89,10 +90,11 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/Abre-Students/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'Abre-Students'";
+		$db->multi_query($sql);
+		$db->close();
 
 	}
 

--- a/modules/Abre-Students/student.php
+++ b/modules/Abre-Students/student.php
@@ -69,7 +69,7 @@
 							echo "<li class='tab col s3'><a href='#assessments'><i class='material-icons hide-on-large-only'>assessment</i><span class='hide-on-med-and-down'>Assessments</span></a></li>";
 							echo "<li class='tab col s3'><a href='#schedule'><i class='material-icons hide-on-large-only'>schedule</i><span class='hide-on-med-and-down'>Schedule</span></a></li>";
 							echo "<li class='tab col s3'><a href='#attendance'><i class='material-icons hide-on-large-only'>alarm</i><span class='hide-on-med-and-down'>Attendance</span></a></li>";
-							if(file_exists("$portal_path_root/modules/Abre-Conduct/setup.txt")){
+							if(isAppActive("Abre-Conduct")){
 								echo "<li class='tab col s3'><a href='#conduct'><i class='material-icons hide-on-large-only'>gavel</i><span class='hide-on-med-and-down'>Conduct</span></a></li>";
 							}
 						echo "</ul>";
@@ -89,7 +89,7 @@
 					echo "</div>";
 
 					echo "<div id='conduct'>";
-						if(file_exists("$portal_path_root/modules/Abre-Conduct/setup.txt")){
+						if(isAppActive("Abre-Conduct")){
 							include "student_conduct.php";
 						}
 					echo "</div>";

--- a/modules/apps/config.php
+++ b/modules/apps/config.php
@@ -258,7 +258,7 @@
 						out_duration: 0,
 					});
 					var url;
-					<?php if(file_exists(realpath(dirname(__FILE__) . '/../Abre-Students/'))){ ?>
+					<?php if(isAppActive("Abre-Students")){ ?>
 						url = "<?php echo $url ?>";
 					<?php }else{ ?>
 						url = "<?php echo $portal_root ?>";

--- a/modules/apps/installer.php
+++ b/modules/apps/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/apps/setup.txt")){
+	if(superadmin() && !isAppInstalled("apps")){
 		//Check for apps table
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 		if(!$db->query("SELECT * FROM apps LIMIT 1")){
@@ -119,9 +119,10 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/apps/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'apps'";
+		$db->multi_query($sql);
+		$db->close();
 	}
 ?>

--- a/modules/directory/installer.php
+++ b/modules/directory/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/directory/setup.txt")){
+	if(superadmin() && !isAppInstalled("directory")){
 
 		//Setup tables if new module
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -157,9 +157,10 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/directory/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'directory'";
+		$db->multi_query($sql);
+		$db->close();
 	}
 ?>

--- a/modules/directory/rolelist.php
+++ b/modules/directory/rolelist.php
@@ -24,7 +24,7 @@
 	echo "<option value='' disabled selected>Choose a Role</option>";
 
 	//Conduct Roles
-	if(file_exists("$portal_path_root/modules/Abre-Conduct/setup.txt")){
+	if(isAppActive("Abre-Conduct")){
 		if(strpos($role, 'Conduct Administrator') !== false){
 			echo "<option value='Conduct Administrator' selected='selected'>Conduct Administrator</option>";
 		}else{
@@ -39,7 +39,7 @@
 	}
 
 	//Curriculum Roles
-	if(file_exists("$portal_path_root/modules/Abre-Curriculum/setup.txt")){
+	if(isAppActive("Abre-Curriculum")){
 		if(strpos($role, 'Curriculum Administrator') !== false){
 			echo "<option value='Curriculum Administrator' selected='selected'>Curriculum Administrator</option>";
 		}else{
@@ -67,7 +67,7 @@
 	}
 
 	//Plans Roles
-	if(file_exists("$portal_path_root/modules/Abre-Plans/setup.txt")){
+	if(isAppActive("Abre-Plans")){
 		if(strpos($role, 'District Plans Administrator') !== false){
 			echo "<option value='District Plans Administrator' selected='selected'>District Plans Administrator</option>";
 		}else{
@@ -82,7 +82,7 @@
 	}
 
 	//Forms Roles
-	if(file_exists("$portal_path_root/modules/Abre-Forms/setup.txt")){
+	if(isAppActive("Abre-Forms")){
 		if(strpos($role, 'Forms Administrator') !== false){
 			echo "<option value='Forms Administrator' selected='selected'>Forms Administrator</option>";
 		}else{

--- a/modules/modules/action_updateactive.php
+++ b/modules/modules/action_updateactive.php
@@ -22,7 +22,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 
-	if(admin()){
+	if(superadmin()){
 
 		//Get POST Variables
 		$uniqueappname=$_POST["uniquename"];

--- a/modules/modules/deletemodule.php
+++ b/modules/modules/deletemodule.php
@@ -39,13 +39,19 @@
 	}
 
 	//Verify superadmin
-	$sql = "SELECT * FROM users WHERE email = '".$_SESSION['useremail']."' AND superadmin = 1";
-	$result = $db->query($sql);
-	while($row = $result->fetch_assoc()){
+	if(superadmin()){
 		//Retrieve last repo link and zip file
 		$module=$_POST["link"];
 
 		//Delete module
 		rrmdir(realpath(dirname(__FILE__))."/../$module");
+
+		$stmt = $db->stmt_init();
+		$sql = "DELETE FROM apps_abre WHERE app = ?";
+		$stmt->prepare($sql);
+		$stmt->bind_param("s", $module);
+		$stmt->execute();
+		$stmt->close();
+		$db->close();
 	}
 ?>

--- a/modules/modules/githubmoduleadd_process.php
+++ b/modules/modules/githubmoduleadd_process.php
@@ -24,9 +24,7 @@
 	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Verify superadmin
-	$sql = "SELECT * FROM users WHERE email = '".$_SESSION['useremail']."' AND superadmin = 1";
-	$result = $db->query($sql);
-	while($row = $result->fetch_assoc()){
+	if(superadmin()){
 
 		//Retrieve the repo
 		$repoaddress = $_POST["repoaddress"];
@@ -54,6 +52,31 @@
 
 		//Delete zipped files
     unlink("$portal_path_root/modules/$project.zip");
+
+		$app = str_replace("/", "", $project);
+		$sql = "SELECT COUNT(*) FROM apps_abre WHERE app = '$app'";
+		$query = $db->query($sql);
+		$result = $query->fetch_assoc();
+		$count = $result["COUNT(*)"];
+		
+		$active = 1;
+		$installed = 0;
+		if($count == 0){
+			$stmt = $db->stmt_init();
+			$insertSql = "INSERT INTO apps_abre (app, active, installed) VALUES (?, ?, ?)";
+			$stmt->prepare($insertSql);
+			$stmt->bind_param("sii", $app, $active, $installed);
+			$stmt->execute();
+			$stmt->close();
+		}else{
+			$stmt = $db->stmt_init();
+			$insertSql = "UPDATE apps_abre SET active = ?, installed = ? WHERE app = ?";
+			$stmt->prepare($insertSql);
+			$stmt->bind_param("iis", $active, $installed, $app);
+			$stmt->execute();
+			$stmt->close();
+		}
+		$db->close();
 
 		echo "Module Added";
 	}

--- a/modules/modules/modals.php
+++ b/modules/modules/modals.php
@@ -21,7 +21,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 ?>
 
-	<!-- Book Code Modal -->
+	<!-- Add module modal -->
 	<div id="addmodule" class="modal modal-fixed-footer modal-mobile-full">
 		<form class="col s12" id="form-addmodule" method="post" action="modules/<?php echo basename(__DIR__); ?>/githubmoduleadd_process.php">
 		<div class="modal-content" style="padding: 0px !important;">

--- a/modules/modules/modules.php
+++ b/modules/modules/modules.php
@@ -23,7 +23,7 @@
 	require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
 
 	//Modules
-	if(admin()){
+	if(superadmin()){
 
 		//List all modules
 		$modules = array();
@@ -85,11 +85,11 @@
 					echo "<td>$version</td>";
 
 					//Active Status
-					$sql = "SELECT COUNT(*) FROM apps_abre WHERE app='$uniquename' AND active='0'";
+					$sql = "SELECT active FROM apps_abre WHERE app='$uniquename'";
 					$query = $db->query($sql);
 					$returnrow = $query->fetch_assoc();
-					$activecount = $returnrow["COUNT(*)"];
-					if($activecount==0){ $checkstatus="checked"; }else{ $checkstatus=""; }
+					$active = $returnrow["active"];
+					if($active == 1){ $checkstatus = "checked"; }else{ $checkstatus = ""; }
 
 					echo "<td class='center-align'>";
 						echo "<div class='switch'>";
@@ -115,12 +115,12 @@
 						}else{
 							echo "<td width=30px></td>";
 						}
+						//Delete module
+						echo "<td width=30px><button class='deletemodule mdl-button mdl-js-button mdl-button--icon mdl-color-text--grey-600' data-module='$project'><i class='material-icons'>delete</i></button></td>";
 					}else{
 						echo "<td width=30px></td>";
+						echo "<td width=30px></td>";
 					}
-
-					//Delete module
-					echo "<td width=30px><button class='deletemodule mdl-button mdl-js-button mdl-button--icon mdl-color-text--grey-600' data-module='$project'><i class='material-icons'>delete</i></button></td>";
 				echo "</tr>";
 			}
 

--- a/modules/profile/config.php
+++ b/modules/profile/config.php
@@ -119,7 +119,7 @@
 			if($responseSize == 0){
 				if($startup['purpose'] == "form"){
 					$formID = $startup['form_id'];
-					if(file_exists("$portal_path_root/modules/Abre-Forms/setup.txt")){
+					if(isAppActive("Abre-Forms")){
 						$sql = "SELECT FormFields FROM forms WHERE ID = '$formID'";
 						$row = $db->query($sql);
 						$result = $row->fetch_assoc();
@@ -134,7 +134,7 @@
 
 	$requiredHeadlinesJSON = json_encode($requiredHeadlines);
 
-	if(file_exists("$portal_path_root/modules/Abre-Forms/setup.txt")){
+	if(isAppActive("Abre-Forms")){
 ?>
 <script src="/modules/Abre-Forms/js/form-render.min.js"></script>
 <?php } ?>

--- a/modules/profile/installer.php
+++ b/modules/profile/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/profile/setup.txt")){
+	if(superadmin() && !isAppInstalled("profile")){
 
     //Setup tables if new module
     require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -174,11 +174,11 @@
 		}
 		$db->close();
 
-
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/profile/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//Mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'profile'";
+		$db->multi_query($sql);
+		$db->close();
 	}
 
 ?>

--- a/modules/profile/modals.php
+++ b/modules/profile/modals.php
@@ -229,7 +229,7 @@
 						<select id="headlinePurpose" name="headlinePurpose">
 							<option value="text" selected>Deliver a Message</option>
 							<option value="video">Deliver a Youtube Video</option>
-							<?php if(file_exists("$portal_path_root/modules/Abre-Forms/setup.txt")){
+							<?php if(isAppActive("Abre-Forms")){
 								echo "<option value='form'>Deliver a Form</option>";
 							} ?>
 						</select>
@@ -240,7 +240,7 @@
 						<label for="headlineForm" class="active">Form</label>
 						<select id="headlineForm" name="headlinForm">
 							<option value="" disabled selected>Attach a Form</option>
-							<?php if(file_exists("$portal_path_root/modules/Abre-Forms/setup.txt")){
+							<?php if(isAppActive("Abre-Forms")){
 								$sql = "SELECT ID, Name FROM forms WHERE Owner = '".$_SESSION['useremail']."'";
 								$result = $db->query($sql);
 								while($value = $result->fetch_assoc()){

--- a/modules/settings/authentication.php
+++ b/modules/settings/authentication.php
@@ -72,7 +72,7 @@
 								echo "<a id='exportkeys' href='#facebookAuthModal' class='modal-action waves-effect btn-flat white-text facebookAuthModal' style='background-color: ".getSiteColor()."'>Configure</a>";
 						echo "</div>";
 					echo "</div>";
-					if($db->query("SELECT * FROM Abre_Students LIMIT 1") && file_exists("$portal_path_root/modules/settings/setup.txt") && admin()){
+					if($db->query("SELECT * FROM Abre_Students LIMIT 1") && isAppActive("settings") && admin()){
 						echo "<div class='row'>";
 							echo "<div class='input-field col l12 s12' style='margin-top:0;'>";
 								echo "<h4>Student Key Management</h4>";

--- a/modules/settings/installer.php
+++ b/modules/settings/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/settings/setup.txt")){
+	if(superadmin() && !isAppInstalled("settings")){
 
 		//Ping Update
 		require(dirname(__FILE__) . '/../../core/abre_ping.php');
@@ -86,9 +86,10 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/settings/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'settings'";
+		$db->multi_query($sql);
+		$db->close();
 	}
 ?>

--- a/modules/settings/settings.php
+++ b/modules/settings/settings.php
@@ -30,6 +30,7 @@
 			echo "<div class='page_container page_container_limit mdl-shadow--4dp'>";
 				echo "<div class='page'>";
 
+				if(superadmin()){
 					//Update Checker
 					$opts = ['http' => ['method' => 'GET','header' => ['User-Agent: PHP']]];
 					$context = stream_context_create($opts);
@@ -41,10 +42,11 @@
 						$currentlink = "https://github.com/abreio/Abre/archive/".$currentversion.".zip";
 						echo "<div class='row'>";
 							echo "<div class='col s12'>";
-								echo "<div id='updateabre' data-version='$currentlink' class='card white-text pointer' style='background-color:#4CAF50; padding:20px;'>A new version of Abre is available. <u>Click here to update to $currentversion.</u></div>";
+								echo "<div id='updateabre' data-version='$currentlink' class='card white-text pointer' style='background-color:".getSiteColor()."; padding:20px;'>A new version of Abre is available. <u>Click here to update to $currentversion.</u></div>";
 							echo "</div>";
 						echo "</div>";
 					}
+				}
 
 					//General Settings
 					echo "<div class='row'>";

--- a/modules/settings/update.php
+++ b/modules/settings/update.php
@@ -144,6 +144,14 @@
 		//Create content folder if one doesn't exist
 		if(!file_exists("$portal_path_root/content/")){ mkdir("$portal_path_root/content/"); }
 
+		$sql = "UPDATE apps_abre SET installed = 0";
+		$db->multi_query($sql);
+
+		$sql = "UPDATE settings SET update_required = 1";
+		$db->multi_query($sql);
+		
+		$db->close();
+
 		//Delete the update directory
 		deleteDirectory("$portal_path_root/update/");
 	}

--- a/modules/settings/update.php
+++ b/modules/settings/update.php
@@ -24,7 +24,7 @@
 	require(dirname(__FILE__) . '/../../core/abre_version.php');
 
 	//Verify admin
-	if(admin()){
+	if(superadmin()){
 		//Retrieve last repo link and zip file
 		$link = $_POST["link"];
 		$linkfile = basename($link);

--- a/modules/stream/installer.php
+++ b/modules/stream/installer.php
@@ -20,7 +20,7 @@
 	require_once(dirname(__FILE__) . '/../../core/abre_verification.php');
 	require_once(dirname(__FILE__) . '/../../core/abre_functions.php');
 
-	if(admin() && !file_exists("$portal_path_root/modules/stream/setup.txt")){
+	if(superadmin() && !isAppInstalled("stream")){
 
 		//Setup tables if new module
 		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
@@ -202,9 +202,10 @@
 		}
 		$db->close();
 
-		//Write the Setup File
-		$myfile = fopen("$portal_path_root/modules/stream/setup.txt", "w");
-		fwrite($myfile, '');
-		fclose($myfile);
+		//mark app as installed
+		require(dirname(__FILE__) . '/../../core/abre_dbconnect.php');
+		$sql = "UPDATE apps_abre SET installed = 1 WHERE app = 'stream'";
+		$db->multi_query($sql);
+		$db->close();
 	}
 ?>


### PR DESCRIPTION
## Enhancements
- Minor permissions change to only allow super admins update the platform.
- Removing setup.txt logic for installers. We are now storing all installed apps in the apps_abre table. A column designates whether or not the installer needs to run.
- All core apps now inherit the version of the core platform.
- Set repo variable value to null for core apps so unnecessary apis are not made from the store page.
- Removed the delete button from core apps on the store page.  